### PR TITLE
修复笔记移动时不能移动到一级目录的bug

### DIFF
--- a/public/js/app/note.js
+++ b/public/js/app/note.js
@@ -2313,16 +2313,38 @@ Note.initContextmenu = function() {
 
 	    this.move = new gui.MenuItem({
 	        label: getMsg("Move"),
-	        submenu: ms[0], // 必须要放这里, 之后不能赋值
 	        click: function(e) {
+	        	dialogOperateNotes({notebooks: notebooks, func: 'move'});
 	        }
 	    });
 	    this.copy = new gui.MenuItem({
 	        label: getMsg("Copy"),
-	        submenu: ms[1],
 	        click: function(e) {
+	        	dialogOperateNotes({notebooks: notebooks, func: 'copy'});
 	        }
 	    });
+	    function dialogOperateNotes(options) {
+	    	$("#leanoteDialog #modalTitle").html(getMsg("selectNotebook"));
+	    	
+	    	$("#leanoteDialog .modal-body").html('<p><font color="red">'+getMsg("doubleClick")+'</font></p><ul id="notebookTree" class="ztree showIcon"></ul>');
+	    	$("#leanoteDialog .modal-footer").html('\
+            	<button type="button" class="btn btn-default" data-dismiss="modal">'+getMsg("Colse")+'</button>\
+            	');
+	    	var callback;
+	    	if ('move' == options.func) {
+	    		callback = function(notebookId){
+					Note.moveNote(Note.target, {notebookId: notebookId});
+				}
+	    	} else if ('copy' == options.func) {
+	    		callback = function(notebookId){
+					Note.copyNote(Note.target, {notebookId: notebookId});
+				}
+	    	}
+	    	var notebookTree = $.fn.zTree.init($("#notebookTree"), Notebook.getSimpleTreeSetting({callback: callback}), options.notebooks);
+			delete options.title;
+			options.show = true;
+			$("#leanoteDialog").modal(options);
+	    }
 
 	    // 本地笔记不能公开为博客
 	    if (!UserInfo.IsLocal) {

--- a/public/js/app/notebook.js
+++ b/public/js/app/notebook.js
@@ -148,6 +148,48 @@ Notebook.getSubNotebooks = function(parentNotebookId) {
 	}
 	return nodes;
 };
+/**
+ * Simple Tree Setting(基本版)
+ * 笔记移动、复制时使用
+ */
+Notebook.getSimpleTreeSetting = function(options) {
+	// 添加自定义dom
+	function addDiyDom(treeId, treeNode) {
+		var spaceWidth = 5;
+		var switchObj = $("#" + treeId + " #" + treeNode.tId + "_switch"),
+		icoObj = $("#" + treeId + " #" + treeNode.tId + "_ico");
+		switchObj.remove();
+		icoObj.before(switchObj);
+
+		if (treeNode.level > 1) {
+			var spaceStr = "<span style='display: inline-block;width:" + (spaceWidth * treeNode.level)+ "px'></span>";
+			switchObj.before(spaceStr);
+		}
+	}
+	var onDblClick =  function(e, treeId, treeNode) {
+		var notebookId = treeNode.NotebookId;
+		options.callback(notebookId);
+		$("#leanoteDialog").modal('hide');
+	};
+	var setting = {
+		view: {
+			showLine: false,
+			showIcon: false,
+			selectedMulti: false,
+			addDiyDom: addDiyDom
+		},
+		data: {
+			key: {
+				name: "Title",
+				children: "Subs",
+			}
+		},
+		callback: {
+			onDblClick: onDblClick
+		}
+	};
+	return setting;
+}
 
 Notebook.getTreeSetting = function(isSearch, isShare) { 
 	var noSearch = !isSearch;

--- a/public/langs/en-us.js
+++ b/public/langs/en-us.js
@@ -96,6 +96,8 @@
     "moto2": "Knowledge, Sharing, Cooperation, Blog... all in leanote",
     "moto3": "Brief But Not Simple",
     "move": "Move to",
+    "doubleClick": "Please 'double-click' the desired folder!",
+    "selectNotebook": "Select Folder",
     "myBlog": "Blog",
     "myNote": "My note",
     "myNotebook": "My notebook",

--- a/public/langs/ja-jp.js
+++ b/public/langs/ja-jp.js
@@ -91,6 +91,8 @@
   "Logout": "ログオフ",
   "minLength": "最小長さが%s",
   "Move": "移動",
+  "doubleClick": "気にいるフォルダを「ダブルクリック」してください",
+  "selectNotebook": "フォルダを選択します",
   "myBlog": "マイブログ",
   "myNote": "マイノート",
   "myNotebook": "マイノートブック",

--- a/public/langs/zh-cn.js
+++ b/public/langs/zh-cn.js
@@ -91,6 +91,8 @@
     "Logout": "注销",
     "minLength": "长度至少为%s",
     "Move": "移动",
+    "doubleClick": "请“双击”期望的文件夹！",
+    "selectNotebook": "选择文件夹",
     "myBlog": "我的博客",
     "myNote": "我的笔记",
     "myNotebook": "我的笔记本",

--- a/public/langs/zh-hk.js
+++ b/public/langs/zh-hk.js
@@ -91,6 +91,8 @@
     "Logout": "登出",
     "minLength": "長度至少為%s",
     "Move": "移動",
+    "doubleClick": "請“雙擊”期望的文件夾！",
+    "selectNotebook": "選擇文件夾",
     "myBlog": "我的部落格",
     "myNote": "我的筆記",
     "myNotebook": "我的記事本",


### PR DESCRIPTION
修复文件移动时不能移动到一级目录的bug
－－

新增getSimpleTreeSetting方法，笔记移动和复制时使用。

此次修改仅仅修复文件夹目录结构的获取方式，实际移动和复制操作调用既存方法。

使用方法，和从前一样的位置进行移动和复制，在弹出框中双击希望选择的文件夹。