### PR TITLE
add dependence ‘mkdirp’ for ‘gulp-utils’

### DIFF
--- a/dev/package.json
+++ b/dev/package.json
@@ -9,7 +9,8 @@
     "gulp-less": "^3.3.0",
     "gulp-rename": "^1.0",
     "gulp-uglify": "^1.0.0",
-    "gulp-util": "^3.0.1"
+    "gulp-util": "^3.0.1",
+    "mkdirp": "^0.5.1"
   },
   "author": "life(http://life.leanote.com)",
   "license": "GPL v2",


### PR DESCRIPTION
for `node`  v7.0.0 and v6.4.0,  the subdir `dev` lack of `mkdirp`, like below:
```
➜  dev git:(master) ✗ gulp dev
module.js:474
    throw err;
    ^

Error: Cannot find module 'mkdirp'
    at Function.Module._resolveFilename (module.js:472:15)
    at Function.Module._load (module.js:420:25)
    at Module.require (module.js:500:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/fanyer/program/electron_workspace/desktop-app/dev/node_modules/vinyl-fs/lib/dest/index.js:6:14)
    at Module._compile (module.js:573:32)
    at Object.Module._extensions..js (module.js:582:10)
    at Module.load (module.js:490:32)
    at tryModuleLoad (module.js:449:12)
    at Function.Module._load (module.js:441:3)
```

It is derive from `vinyl-fs` under `gulp-utils`. As a result, I make a PR to fix it.