### PR TITLE
prevent always sync by using cmd + s

### DIFF
--- a/public/js/app/note.js
+++ b/public/js/app/note.js
@@ -1405,7 +1405,7 @@ Note.syncProcess = function(msg) {
 Note.saveNote = function(e) {
     var num = e.which ? e.which : e.keyCode;
     // 保存
-    if ((e.ctrlKey || e.metaKey) && num == 83) { // ctrl + s or command + s
+    if ((e.ctrlKey || e.metaKey) && num == 83 && editorIsDirty()) { // ctrl + s or command + s
         incrSync(true);
         e.preventDefault();
         return false;


### PR DESCRIPTION
always cmd+s and trigger sync lead to high CPU overhead and low battery life. But there are something wrong with my electron environment. So if you can help testing it, I'll be grateful. Only one line of code is changed.