### PR TITLE
Pass note titles through trimTitle() to avoid XSS (#353)

### DIFF
--- a/public/js/app/note.js
+++ b/public/js/app/note.js
@@ -1175,9 +1175,9 @@ Note._getNoteHtmlObjct = function(note, isShared) {
 
             var tmp;
             if (note.ImgSrc) {
-                tmp = tt(Note.getItemTpl(), classes, i, note.NoteId, Note.fixImageSrc(note.ImgSrc), note.Title || getMsg('UnTitled'), Notebook.getNotebookTitle(note.NotebookId), goNowToDatetime(note.UpdatedTime), note.Desc || '');
+                tmp = tt(Note.getItemTpl(), classes, i, note.NoteId, Note.fixImageSrc(note.ImgSrc), trimTitle(note.Title) || getMsg('UnTitled'), Notebook.getNotebookTitle(note.NotebookId), goNowToDatetime(note.UpdatedTime), note.Desc || '');
             } else {
-                tmp = tt(Note.getItemTplNoImg(), classes, i, note.NoteId, note.Title || getMsg('UnTitled'), Notebook.getNotebookTitle(note.NotebookId), goNowToDatetime(note.UpdatedTime), note.Desc || '');
+                tmp = tt(Note.getItemTplNoImg(), classes, i, note.NoteId, trimTitle(note.Title) || getMsg('UnTitled'), Notebook.getNotebookTitle(note.NotebookId), goNowToDatetime(note.UpdatedTime), note.Desc || '');
             }
 
             Note.noteItemListO.append(tmp);
@@ -3234,7 +3234,7 @@ Note.batch = {
             return;
         }
         var note = Note.getNote(noteId);
-        var title = note.Title || getMsg('unTitled');
+        var title = trimTitle(note.Title) || getMsg('unTitled');
         var desc = note.Desc || '...';
         // desc = substr(note.Content, 0, 200);
 


### PR DESCRIPTION
This doesn't fix the underlying issues I described in #353 but it does at least provide a hotfix to prevent the vulnerabilities from being immediately and trivially exploitable.